### PR TITLE
Delete ebs volumes on termination of the instances

### DIFF
--- a/ansible/aws_coreos_site.yml
+++ b/ansible/aws_coreos_site.yml
@@ -129,6 +129,7 @@
         volumes:
           - device_name: /dev/xvda
             volume_size: 30
+            delete_on_termination: true
         count_tag:
           Name: "ftstt{{cp.msg}}-caw1{{az}}-eu-p"
         instance_tags:
@@ -160,8 +161,10 @@
         volumes:
           - device_name: /dev/xvda
             volume_size: 30
+            delete_on_termination: true
           - device_name: /dev/xvdf
             volume_size: 80
+            delete_on_termination: true
         count_tag:
           Name: "ftpr1{{cp.msg}}-caw1{{az}}-eu-p"
         instance_tags:
@@ -193,8 +196,10 @@
         volumes:
           - device_name: /dev/xvda
             volume_size: 30
+            delete_on_termination: true
           - device_name: /dev/xvdf
             volume_size: 80
+            delete_on_termination: true
         count_tag:
           Name: "ftpr2{{cp.msg}}-caw1{{az}}-eu-p"
         instance_tags:
@@ -226,8 +231,10 @@
         volumes:
           - device_name: /dev/xvda
             volume_size: 30
+            delete_on_termination: true
           - device_name: /dev/xvdf
             volume_size: 80
+            delete_on_termination: true
         count_tag:
           Name: "ftpr3{{cp.msg}}-caw1{{az}}-eu-p"
         instance_tags:


### PR DESCRIPTION
At least for now, as we are doing a lot of R&D work and create tonnes of
orphaned EBS volumes