### PR TITLE
Attempt auto repair of fs when doing the check for fs presence

### DIFF
--- a/ansible/userdata/persistent_instance_user_data_1.yaml
+++ b/ansible/userdata/persistent_instance_user_data_1.yaml
@@ -29,7 +29,7 @@ coreos:
         Before=vol.mount
         [Service]
         Type=oneshot
-        ExecStart=/bin/bash -c "/usr/sbin/fsck /dev/xvdf || /usr/sbin/mkfs.ext4 /dev/xvdf"
+        ExecStart=/bin/bash -c "/usr/sbin/fsck -a /dev/xvdf || /usr/sbin/mkfs.ext4 /dev/xvdf"
         ExecStart=/bin/bash -c "/usr/bin/test -e /vol || /usr/bin/mkdir /vol"
     - name: vol.mount
       command: start

--- a/ansible/userdata/persistent_instance_user_data_2.yaml
+++ b/ansible/userdata/persistent_instance_user_data_2.yaml
@@ -29,7 +29,7 @@ coreos:
         Before=vol.mount
         [Service]
         Type=oneshot
-        ExecStart=/bin/bash -c "/usr/sbin/fsck /dev/xvdf || /usr/sbin/mkfs.ext4 /dev/xvdf"
+        ExecStart=/bin/bash -c "/usr/sbin/fsck -a /dev/xvdf || /usr/sbin/mkfs.ext4 /dev/xvdf"
         ExecStart=/bin/bash -c "/usr/bin/test -e /vol || /usr/bin/mkdir /vol"
     - name: vol.mount
       command: start

--- a/ansible/userdata/persistent_instance_user_data_3.yaml
+++ b/ansible/userdata/persistent_instance_user_data_3.yaml
@@ -29,7 +29,7 @@ coreos:
         Before=vol.mount
         [Service]
         Type=oneshot
-        ExecStart=/bin/bash -c "/usr/sbin/fsck /dev/xvdf || /usr/sbin/mkfs.ext4 /dev/xvdf"
+        ExecStart=/bin/bash -c "/usr/sbin/fsck -a /dev/xvdf || /usr/sbin/mkfs.ext4 /dev/xvdf"
         ExecStart=/bin/bash -c "/usr/bin/test -e /vol || /usr/bin/mkdir /vol"
     - name: vol.mount
       command: start


### PR DESCRIPTION
Previously the the filesystem got remade on every boot, as it tried to run in interactive mode, not get a tty, and return non-zero: https://pastee.org/vak44

This change adds `-a` flag to fsck, which makes it run non-interactively and passes through on clean fs. Will also attempt to repair any faults found and if unable to will only **then** erase and make new fs. 