### PR TITLE
Remove insecure registry option

### DIFF
--- a/ansible/aws_coreos_site.yml
+++ b/ansible/aws_coreos_site.yml
@@ -6,7 +6,6 @@
     az: b
     ami: ami-eb97bc9c #eu-west-1 HMV 766.4.0 (stable)
     #ami: ami-c3cae3b4 #eu-west-1 HMV CoreOS 815.0.0 (alpha)
-    insecure_registry: up-registry.ft.com
     env: p
     ipcode: P295
     systemCode: "CoreOS-Universal-Publishing"

--- a/ansible/userdata/default_instance_user_data.yaml
+++ b/ansible/userdata/default_instance_user_data.yaml
@@ -110,10 +110,6 @@ write_files:
     content: |
       [Socket]
       ListenStream=0.0.0.0:49153
-  - path: /etc/systemd/system/docker.service.d/mirror.conf
-    content: |
-      [Service]
-      Environment="DOCKER_OPTS=--insecure-registry={{insecure_registry}}"
   - path: /etc/motd.d/env.conf
     content: |
             This enviroment is tagged as {{environment_tag}} and is cluster {{token}}

--- a/ansible/userdata/persistent_instance_user_data_1.yaml
+++ b/ansible/userdata/persistent_instance_user_data_1.yaml
@@ -88,10 +88,6 @@ write_files:
     content: |
       [Socket]
       ListenStream=0.0.0.0:49153
-  - path: /etc/systemd/system/docker.service.d/mirror.conf
-    content: |
-      [Service]
-      Environment="DOCKER_OPTS=--insecure-registry={{insecure_registry}}"
   - path: /etc/motd.d/env.conf
     content: |
             This enviroment is tagged as {{environment_tag}} and is cluster {{token}}

--- a/ansible/userdata/persistent_instance_user_data_2.yaml
+++ b/ansible/userdata/persistent_instance_user_data_2.yaml
@@ -88,10 +88,6 @@ write_files:
     content: |
       [Socket]
       ListenStream=0.0.0.0:49153
-  - path: /etc/systemd/system/docker.service.d/mirror.conf
-    content: |
-      [Service]
-      Environment="DOCKER_OPTS=--insecure-registry={{insecure_registry}}"
   - path: /etc/motd.d/env.conf
     content: |
             This enviroment is tagged as {{environment_tag}} and is cluster {{token}}

--- a/ansible/userdata/persistent_instance_user_data_3.yaml
+++ b/ansible/userdata/persistent_instance_user_data_3.yaml
@@ -88,10 +88,6 @@ write_files:
     content: |
       [Socket]
       ListenStream=0.0.0.0:49153
-  - path: /etc/systemd/system/docker.service.d/mirror.conf
-    content: |
-      [Service]
-      Environment="DOCKER_OPTS=--insecure-registry={{insecure_registry}}"
   - path: /etc/motd.d/env.conf
     content: |
             This enviroment is tagged as {{environment_tag}} and is cluster {{token}}


### PR DESCRIPTION
up-registry.ft.com is now behind SSL, docker should have no problems
resolving/connecting to it. Auth to follow