### PR TITLE
Adding 62.25.64.1 into Fleet security group

### DIFF
--- a/ansible/aws_coreos_site.yml
+++ b/ansible/aws_coreos_site.yml
@@ -82,6 +82,11 @@
             from_port: 49153
             to_port: 49153
             cidr_ip: 52.16.117.250/32
+          # VPN client's outbound IP via tun0 interface
+          - proto: tcp
+            from_port: 22
+            to_port: 22
+            cidr_ip: 62.25.64.1/32
           # Allow 80 from everywhere
           - proto: tcp
             from_port: 80


### PR DESCRIPTION
Adding 62.25.64.1 into Fleet security group, provides SSH access to VPN users