### PR TITLE
Service that starts deployer honours the boot flag

### DIFF
--- a/ansible/userdata/default_instance_user_data.yaml
+++ b/ansible/userdata/default_instance_user_data.yaml
@@ -117,6 +117,8 @@ coreos:
           Description=Start fleet services
           After=fleet.service
           Requires=fleet.service
+          # Only run on first boot
+          ConditionPathExists=!/var/lib/format-done
 
           [Service]
           Type=oneshot


### PR DESCRIPTION
Pull and start the deployer only on the first boot.