### PR TITLE
Update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,12 +63,6 @@ export CLUSTER_BASIC_HTTP_CREDENTIALS=
 ##Gateway content api host to access UPP content that the cluster read endpoints (e.g. CPR & CPR-preview) are mapped to. 
 ##The default is prod DNS name given by Mashery but if we are creating a cluster not for prod then some different DNS name may be required, e.g. http://test.api.ft.com or some such
 export API_HOST=http://api.ft.com
-
-##URLs to Bertha endpoints  for accessing to specific Google Spreadsheet data.
-##AUTHORS_BERTHA_URL refers to the spreadsheet of curated authors data.
-##ROLES_BERTHA_URL refers to the spreadsheet of roles for curated authors.
-export AUTHORS_BERTHA_URL=http://bertha.site.example/123456XYZ/Authors
-export ROLES_BERTHA_URL=http://bertha.site.example/123456XYZ/Roles
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -31,21 +31,19 @@ Set all the required variables
 ## `curl https://discovery.etcd.io/new?size=5`
 export TOKEN_URL=`curl https://discovery.etcd.io/new?size=5`
 
-## Secret used during provision to decrypt keys - get it off your closest buddy!
+## Secret used during provision to decrypt keys - stored in LastPass.
 ## Lastpass: coco-provisioner-ansible-vault-pass
 export VAULT_PASS=
 
-## AWS API keys, get these off your buddy too
+## AWS API keys for provisioning (not for use by services) - stored in LastPass.
 ## Lastpass: infraprod-coco-aws-provisioning-keys
 export AWS_ACCESS_KEY_ID=
 export AWS_SECRET_ACCESS_KEY=
 
-## S3 bucket name to write image binaries to (up stack specific)
+## S3 bucket name to write image binaries to.
+## Prod: com.ft.imagepublish.prod
+## Pre-Prod: com.ft.coco-imagepublish.pre-prod
 export BINARY_WRITER_BUCKET=
-
-## Only needed for decomissioning
-## To create a cluster in another region, manually edit the provisioner
-export AWS_DEFAULT_REGION=
 
 ## `uuidgen` or set manually each of these when creating new cluster, otherwise: they will be automatically generated during the cluster setup (in this case it is not required to pass them at `docker run`)
 export AWS_MONITOR_TEST_UUID=`uuidgen`
@@ -53,16 +51,22 @@ export COCO_MONITOR_TEST_UUID=`uuidgen`
 
 ## Base uri where your unit definition file and service files are expected to be.
 export SERVICES_DEFINITION_ROOT_URI=https://raw.githubusercontent.com/Financial-Times/up-service-files/master/
+
 ## make a unique identifier (this will be used for DNS tunnel, splunk, AWS tags)
 export ENVIRONMENT_TAG=
-## Comma separated list of urls pointing to the message queue http proxy instances used to bridge platforms(UCS and coco). Optional, defaults to Prod UCS proxy: https://kafka-proxy-iw-uk-p-1.glb.ft.com,https://kafka-proxy-iw-uk-p-2.glb.ft.com
-export BRIDGING_MESSAGE_QUEUE_PROXY= #[Optional]
-##Comma separated username:password which will be used to authenticate(Basic auth) when connecting to the cluster over https.
-Lastpass: CoCo Basic Auth
+
+## Comma separated list of urls pointing to the message queue http proxy instances used to bridge platforms(UCS and coco). 
+## This should always point at Prod - use separate service files to bridge from Test into lower environments.
+export BRIDGING_MESSAGE_QUEUE_PROXY=https://kafka-proxy-iw-uk-p-1.glb.ft.com,https://kafka-proxy-iw-uk-p-2.glb.ft.com
+
+## Comma separated username:password which will be used to authenticate(Basic auth) when connecting to the cluster over https.
+## See Lastpass: 'CoCo Basic Auth' for current cluster values.
 export CLUSTER_BASIC_HTTP_CREDENTIALS=
-##Gateway content api hostname (not URL) to access UPP content that the cluster read endpoints (e.g. CPR & CPR-preview) are mapped to. 
-##The default is prod DNS name given by Mashery but if we are creating a cluster not for prod then some different DNS name may be required, e.g. test.api.ft.com or some such
-export API_HOST=api.ft.com
+
+## Gateway content api hostname (not URL) to access UPP content that the cluster read endpoints (e.g. CPR & CPR-preview) are mapped to. 
+## Prod: api.ft.com
+## Pre-Prod: test.api.ft.com
+export API_HOST=
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -60,9 +60,9 @@ export BRIDGING_MESSAGE_QUEUE_PROXY= #[Optional]
 ##Comma separated username:password which will be used to authenticate(Basic auth) when connecting to the cluster over https.
 Lastpass: CoCo Basic Auth
 export CLUSTER_BASIC_HTTP_CREDENTIALS=
-##Gateway content api host to access UPP content that the cluster read endpoints (e.g. CPR & CPR-preview) are mapped to. 
-##The default is prod DNS name given by Mashery but if we are creating a cluster not for prod then some different DNS name may be required, e.g. http://test.api.ft.com or some such
-export API_HOST=http://api.ft.com
+##Gateway content api hostname (not URL) to access UPP content that the cluster read endpoints (e.g. CPR & CPR-preview) are mapped to. 
+##The default is prod DNS name given by Mashery but if we are creating a cluster not for prod then some different DNS name may be required, e.g. test.api.ft.com or some such
+export API_HOST=api.ft.com
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ export BRIDGING_MESSAGE_QUEUE_PROXY=https://kafka-proxy-iw-uk-p-1.glb.ft.com,htt
 export CLUSTER_BASIC_HTTP_CREDENTIALS=
 
 ## Gateway content api hostname (not URL) to access UPP content that the cluster read endpoints (e.g. CPR & CPR-preview) are mapped to. 
+## Defaults to Prod if left blank.
 ## Prod: api.ft.com
 ## Pre-Prod: test.api.ft.com
 export API_HOST=

--- a/provision.sh
+++ b/provision.sh
@@ -22,7 +22,7 @@ AMI=`curl -s https://coreos.com/dist/aws/aws-stable.json | jq -r '.["eu-west-1"]
   coco_image_monitor_test_uuid=$COCO_MONITOR_TEST_UUID \
   bridging_message_queue_proxy=${BRIDGING_MESSAGE_QUEUE_PROXY:=https://kafka-proxy-iw-uk-p-1.glb.ft.com,https://kafka-proxy-iw-uk-p-2.glb.ft.com} \
   varnish_access_credentials=${CLUSTER_BASIC_HTTP_CREDENTIALS} \
-  api_host=${API_HOST:=http://api.ft.com} \
+  api_host=${API_HOST:=api.ft.com} \
   authors_bertha_url=${AUTHORS_BERTHA_URL} \
   roles_bertha_url=${ROLES_BERTHA_URL} \
   environment_tag=${ENVIRONMENT_TAG:=default}" \


### PR DESCRIPTION
Updating readme to remove bertha environment variables, changing API_HOST defaults + example from URLs to hostnames.