### PR TITLE
Change hosts attribute value from localhost to 127.0.0.1

### DIFF
--- a/ansible/aws_coreos_site.yml
+++ b/ansible/aws_coreos_site.yml
@@ -1,4 +1,4 @@
-- hosts: localhost
+- hosts: 127.0.0.1
   connection: local
 
   vars:

--- a/ansible/decom.yml
+++ b/ansible/decom.yml
@@ -1,4 +1,4 @@
-- hosts: localhost
+- hosts: 127.0.0.1
   connection: local
 
   vars:

--- a/ansible/print_userdata.yml
+++ b/ansible/print_userdata.yml
@@ -1,4 +1,4 @@
-- hosts: localhost
+- hosts: 127.0.0.1
   connection: local
 
   vars:


### PR DESCRIPTION
localhost sometimes results in Ansible running playbook on 2 hosts: localhost and 127.0.0.1
Changing the value to 127.0.0.1 will avoid this issue occurring.

When issue occurs Ansible reports the following events:
TASK [setup] *******************************************************************
ok: [localhost]
ok: [127.0.0.1]

After change Ansible reports it:
TASK [setup] *******************************************************************
ok: [127.0.0.1]