### PR TITLE
Adding journald changes to provisioner

### DIFF
--- a/ansible/userdata/default_instance_user_data.yaml
+++ b/ansible/userdata/default_instance_user_data.yaml
@@ -145,3 +145,9 @@ write_files:
       TOOLBOX_DOCKER_IMAGE=coco/coco-toolbox
       TOOLBOX_DOCKER_TAG=latest
       TOOLBOX_USER=root 
+  - path: /etc/systemd/journald.conf.d/10-override-config.conf
+    content: |
+      [Journal]
+      MaxLevelConsole=crit
+      Compress=false
+      

--- a/ansible/userdata/persistent_instance_user_data.yaml
+++ b/ansible/userdata/persistent_instance_user_data.yaml
@@ -109,4 +109,9 @@ write_files:
       TOOLBOX_DOCKER_IMAGE=coco/coco-toolbox
       TOOLBOX_DOCKER_TAG=latest
       TOOLBOX_USER=root
-
+  - path: /etc/systemd/journald.conf.d/10-override-config.conf
+    content: |
+      [Journal]
+      MaxLevelConsole=crit
+      Compress=false
+      


### PR DESCRIPTION
Tested by spinning up new 5 node cluster and confirmed that file /etc/systemd/journald.conf.d/10-override-config.conf was created automatically.

Here is console out from one of the cluster nodes after provisioning. 
core@ip-172-24-65-52 ~ $ cat /etc/systemd/journald.conf.d/10-override-config.conf
[Journal]
MaxLevelConsole=crit
Compress=fals