### PR TITLE
Enable AWS EBS-Optimized Instances

### DIFF
--- a/ansible/aws_coreos_site.yml
+++ b/ansible/aws_coreos_site.yml
@@ -241,6 +241,7 @@
         instance_type: "{{instanceType}}" 
         wait: true
         exact_count: 1
+        ebs_optimized: true
         user_data: "{{ lookup('template', 'userdata/persistent_instance_user_data.yaml') }}"
         vpc_subnet_id: "{{ vpc.subnets[0].id }}"
         assign_public_ip: yes
@@ -278,6 +279,7 @@
         instance_type: "{{instanceType}}" 
         wait: true
         exact_count: 1
+        ebs_optimized: true
         user_data: "{{ lookup('template', 'userdata/persistent_instance_user_data.yaml') }}"
         vpc_subnet_id: "{{ vpc.subnets[1].id }}"
         assign_public_ip: yes
@@ -315,6 +317,7 @@
         instance_type: "{{instanceType}}"
         wait: true
         exact_count: 1
+        ebs_optimized: true
         user_data: "{{ lookup('template', 'userdata/persistent_instance_user_data.yaml') }}"
         vpc_subnet_id: "{{ vpc.subnets[2].id }}"
         assign_public_ip: yes


### PR DESCRIPTION
For EC2 instances that use persistence I have enabled instance to be
EBS-Optimized.