### PR TITLE
Add ft environment type

### DIFF
--- a/DEVELOPER_README.md
+++ b/DEVELOPER_README.md
@@ -51,7 +51,7 @@ export ENVIRONMENT_TAG=
 ## Set the FT environment type
 ## For PROD: p
 ## For TEST: t
-export ENVIRONMENT_TAG=
+export ENVIRONMENT_TYPE=
 
 ## Comma separated list of urls pointing to the message queue http proxy instances used to bridge platforms(UCS and coco). 
 ## This should always point at Prod - use separate service files to bridge from Test into lower environments.

--- a/DEVELOPER_README.md
+++ b/DEVELOPER_README.md
@@ -48,6 +48,11 @@ export SERVICES_DEFINITION_ROOT_URI=https://raw.githubusercontent.com/Financial-
 ## make a unique identifier (this will be used for DNS tunnel, splunk, AWS tags)
 export ENVIRONMENT_TAG=
 
+## Set the FT environment type
+## For PROD: p
+## For TEST: t
+export ENVIRONMENT_TAG=
+
 ## Comma separated list of urls pointing to the message queue http proxy instances used to bridge platforms(UCS and coco). 
 ## This should always point at Prod - use separate service files to bridge from Test into lower environments.
 export BRIDGING_MESSAGE_QUEUE_PROXY=https://kafka-proxy-iw-uk-p-1.glb.ft.com,https://kafka-proxy-iw-uk-p-2.glb.ft.com
@@ -79,6 +84,7 @@ docker run \
     -e "AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY" \
     -e "AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID" \
     -e "ENVIRONMENT_TAG=$ENVIRONMENT_TAG" \
+    -e "ENVIRONMENT_TYPE=$ENVIRONMENT_TYPE" \
     -e "BINARY_WRITER_BUCKET=$BINARY_WRITER_BUCKET" \
     -e "AWS_MONITOR_TEST_UUID=$AWS_MONITOR_TEST_UUID" \
     -e "COCO_MONITOR_TEST_UUID=$COCO_MONITOR_TEST_UUID" \

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ docker run \
     -e "API_HOST=$API_HOST" \
     -e "CLUSTER_BASIC_HTTP_CREDENTIALS=$CLUSTER_BASIC_HTTP_CREDENTIALS" \
     -e "ENVIRONMENT_TYPE=$ENVIRONMENT_TYPE" \
-    coco/coco-provisioner:v1.0.2
+    coco/coco-provisioner:v1.0.3
 
 ## If the cluster is running, set up HTTPS support (see below)
 ```
@@ -109,7 +109,7 @@ docker run \
   -e "AWS_DEFAULT_REGION=$AWS_DEFAULT_REGION" \
   -e "AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY" \
   -e "AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID" \
-  coco/coco-provisioner:v1.0.2 /bin/bash /decom.sh
+  coco/coco-provisioner:v1.0.3 /bin/bash /decom.sh
 ```
 
 Sometimes cleanup takes a long time and ELBs/Security Groups still get left behind. Other ways to clean up:

--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ docker run \
     -e "BRIDGING_MESSAGE_QUEUE_PROXY=$BRIDGING_MESSAGE_QUEUE_PROXY" \
     -e "API_HOST=$API_HOST" \
     -e "CLUSTER_BASIC_HTTP_CREDENTIALS=$CLUSTER_BASIC_HTTP_CREDENTIALS" \
+    -e "ENVIRONMENT_TYPE=$ENVIRONMENT_TYPE" \
     coco/coco-provisioner:v1.0.2
 
 ## If the cluster is running, set up HTTPS support (see below)

--- a/ansible/aws_coreos_site.yml
+++ b/ansible/aws_coreos_site.yml
@@ -5,7 +5,7 @@
     region: eu-west-1
     ami: ami-c26bcab1 #eu-west-1 HMV 835.9.0 (stable)
     #ami: ami-c3cae3b4 #eu-west-1 HMV CoreOS 815.0.0 (alpha)
-    env: p
+    env: "{{ environment_type }}"
     ipcode: P196
     systemCode: "CoreOS-Universal-Publishing"
     description: "CoreOS-Universal-Publishing"
@@ -22,30 +22,30 @@
         region: "{{region}}"
         state: present
         cidr_block: 172.24.0.0/16
-        resource_tags: {"Name": "coreos", "env": "p", "ipcode": "P196", "systemCode": "CoreOS", "description": "CoreOS", "teamDL": "universal.publishing.platform@ft.com}"}
+        resource_tags: {"Name": "coreos", "env": "{{ env }}", "ipcode": "P196", "systemCode": "CoreOS", "description": "CoreOS", "teamDL": "universal.publishing.platform@ft.com}"}
         subnets:
           - cidr: 172.24.0.0/18
             az:  "{{ region }}a"
-            resource_tags: {"Name": "coreos", "env": "p", "ipcode": "P196", "systemCode": "CoreOS", "description": "CoreOS subnet A", "teamDL": "universal.publishing.platform@ft.com}"}
+            resource_tags: {"Name": "coreos", "env": "{{ env }}", "ipcode": "P196", "systemCode": "CoreOS", "description": "CoreOS subnet A", "teamDL": "universal.publishing.platform@ft.com}"}
 
           - cidr: 172.24.64.0/18
             az:  "{{ region }}b"
-            resource_tags: {"Name": "coreos", "env": "p", "ipcode": "P196", "systemCode": "CoreOS", "description": "CoreOS subnet B", "teamDL": "universal.publishing.platform@ft.com}"}
+            resource_tags: {"Name": "coreos", "env": "{{ env }}", "ipcode": "P196", "systemCode": "CoreOS", "description": "CoreOS subnet B", "teamDL": "universal.publishing.platform@ft.com}"}
 
           - cidr: 172.24.128.0/18
             az:  "{{ region }}c"
-            resource_tags: {"Name": "coreos", "env": "p", "ipcode": "P196", "systemCode": "CoreOS", "description": "CoreOS subnet C", "teamDL": "universal.publishing.platform@ft.com}"}
+            resource_tags: {"Name": "coreos", "env": "{{ env }}", "ipcode": "P196", "systemCode": "CoreOS", "description": "CoreOS subnet C", "teamDL": "universal.publishing.platform@ft.com}"}
 
           # AlertLogic/CloudInsight subnets. Not used by Coco cluster.
           - cidr: 172.24.192.0/28
             az:  "{{ region }}c"
-            resource_tags: {"Name": "coreos", "env": "p", "ipcode": "P196", "systemCode": "CoreOS", "description": "AlertLogic/CloudInsight subnet", "teamDL": "universal.publishing.platform@ft.com}"}
+            resource_tags: {"Name": "coreos", "env": "{{ env }}", "ipcode": "P196", "systemCode": "CoreOS", "description": "AlertLogic/CloudInsight subnet", "teamDL": "universal.publishing.platform@ft.com}"}
           - cidr: 172.24.192.16/28
             az:  "{{ region }}a"
-            resource_tags: {"Name": "coreos", "env": "p", "ipcode": "P196", "systemCode": "CoreOS", "description": "AlertLogic/CloudInsight subnet", "teamDL": "universal.publishing.platform@ft.com}"}
+            resource_tags: {"Name": "coreos", "env": "{{ env }}", "ipcode": "P196", "systemCode": "CoreOS", "description": "AlertLogic/CloudInsight subnet", "teamDL": "universal.publishing.platform@ft.com}"}
           - cidr: 172.24.192.32/28
             az:  "{{ region }}a"
-            resource_tags: {"Name": "coreos", "env": "p", "ipcode": "P196", "systemCode": "CoreOS", "description": "AlertLogic/CloudInsight subnet", "teamDL": "universal.publishing.platform@ft.com}"}
+            resource_tags: {"Name": "coreos", "env": "{{ env }}", "ipcode": "P196", "systemCode": "CoreOS", "description": "AlertLogic/CloudInsight subnet", "teamDL": "universal.publishing.platform@ft.com}"}
 
         internet_gateway: True
         route_tables:

--- a/print-userdata.sh
+++ b/print-userdata.sh
@@ -19,7 +19,8 @@ CLUSTERID=`echo $TOKEN_URL | sed "s/http.*\///g" | cut -c1-8`
   aws_image_monitor_test_uuid=$AWS_MONITOR_TEST_UUID \
   coco_image_monitor_test_uuid=$COCO_MONITOR_TEST_UUID \
   bridging_message_queue_proxy=${BRIDGING_MESSAGE_QUEUE_PROXY:=https://kafka-proxy-iw-uk-p-1.glb.ft.com,https://kafka-proxy-iw-uk-p-2.glb.ft.com} \
-  environment_tag=${ENVIRONMENT_TAG:=default}" \
+  environment_tag=${ENVIRONMENT_TAG:=default} \
+  environment_type=${ENVIRONMENT_TYPE:=p}" \
   --vault-password-file=/vault.pass
 
 echo "Default:"

--- a/provision.sh
+++ b/provision.sh
@@ -23,6 +23,7 @@ AMI=`curl -s https://coreos.com/dist/aws/aws-stable.json | jq -r '.["eu-west-1"]
   bridging_message_queue_proxy=${BRIDGING_MESSAGE_QUEUE_PROXY:=https://kafka-proxy-iw-uk-p-1.glb.ft.com,https://kafka-proxy-iw-uk-p-2.glb.ft.com} \
   varnish_access_credentials=${CLUSTER_BASIC_HTTP_CREDENTIALS} \
   api_host=${API_HOST:=api.ft.com} \
-  environment_tag=${ENVIRONMENT_TAG:=default}" \
+  environment_tag=${ENVIRONMENT_TAG:=default} \
+  environment_type=${ENVIRONMENT_TYPE:=p}" \
   --vault-password-file=/vault.pass
 


### PR DESCRIPTION
Tag instances, ELBs, SGs etc with the appropriate environment type (eg, 'p' for prod, 't' for non-prod), rather than just tagging everything as prod.

Defaults to 'p' if no environment variable is set (as per the current behaviour).

Environment variables for test and prod clusters have been updated in LastPass.