### PR TITLE
Fix clusterid typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ docker run \
     -e "API_HOST=$API_HOST" \
     -e "CLUSTER_BASIC_HTTP_CREDENTIALS=$CLUSTER_BASIC_HTTP_CREDENTIALS" \
     -e "ENVIRONMENT_TYPE=$ENVIRONMENT_TYPE" \
-    coco/coco-provisioner:v1.0.4
+    coco/coco-provisioner:v1.0.7
 
 ```
 
@@ -108,7 +108,7 @@ docker run \
   -e "AWS_DEFAULT_REGION=$AWS_DEFAULT_REGION" \
   -e "AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY" \
   -e "AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID" \
-  coco/coco-provisioner:v1.0.4 /bin/bash /decom.sh
+  coco/coco-provisioner:v1.0.7 /bin/bash /decom.sh
 ```
 
 Sometimes cleanup takes a long time and ELBs/Security Groups still get left behind. Other ways to clean up:

--- a/README.md
+++ b/README.md
@@ -53,7 +53,6 @@ docker run \
     -e "ENVIRONMENT_TYPE=$ENVIRONMENT_TYPE" \
     coco/coco-provisioner:v1.0.4
 
-## If the cluster is running, set up HTTPS support (see below)
 ```
 
 If you need a Docker runtime environment to provision a cluster you can set up [Coco Management Server](https://github.com/Financial-Times/coco-provisioner/blob/master/cloudformation/README.md) in AWS.

--- a/decom.sh
+++ b/decom.sh
@@ -5,8 +5,8 @@ echo "aws_secret_access_key = $AWS_SECRET_ACCESS_KEY" >> /etc/boto.cfg
 ## activate virtual environment
 . .venv/bin/activate
 
-CLUSTER_ID=$(aws ec2 describe-instances --filter Name=tag:coco-environment-tag,Values=$ENVIRONMENT_TAG | jq '.Reservations[0].Instances[0].Tags[]' | cluster-id-extractor)
-echo "ClusterID: $CLUSTER_ID"
+CLUSTERID=$(aws ec2 describe-instances --filter Name=tag:coco-environment-tag,Values=$ENVIRONMENT_TAG | jq '.Reservations[0].Instances[0].Tags[]' | cluster-id-extractor)
+echo "ClusterID: $CLUSTERID"
 
 INSTANCE_IDS=$(aws ec2 describe-instances --filter Name=tag:coco-environment-tag,Values=$ENVIRONMENT_TAG | jq '{"instanceIds": [.Reservations[].Instances[].InstanceId]}')
 INSTANCE_IDS=`echo $INSTANCE_IDS`


### PR DESCRIPTION
This fixes the bug where ELBs and SGs aren't being removed properly when the decomission scripts are run.
Test cluster spun up and torn down successfully.