### PR TITLE
Auto termination protection

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ docker run \
     -e "API_HOST=$API_HOST" \
     -e "CLUSTER_BASIC_HTTP_CREDENTIALS=$CLUSTER_BASIC_HTTP_CREDENTIALS" \
     -e "ENVIRONMENT_TYPE=$ENVIRONMENT_TYPE" \
-    coco/coco-provisioner:v1.0.10
+    coco/coco-provisioner:v1.0.11
 
 ```
 
@@ -90,7 +90,7 @@ docker run \
   -e "AWS_DEFAULT_REGION=$AWS_DEFAULT_REGION" \
   -e "AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY" \
   -e "AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID" \
-  coco/coco-provisioner:v1.0.10 /bin/bash /decom.sh
+  coco/coco-provisioner:v1.0.11 /bin/bash /decom.sh
 ```
 
 Coco Management Server

--- a/ansible/aws_coreos_site.yml
+++ b/ansible/aws_coreos_site.yml
@@ -171,7 +171,7 @@
 
     - name: Set termination protection for production clusters
       set_fact:
-        termination_protection: "{% if env == 'p' %} 'yes' {% else %} 'no' {% endif %}"
+        termination_protection: "{% if env == 'p' %}yes{% else %}no{% endif %}"
 
     - name: Provision m3.large instances
       ec2:

--- a/ansible/aws_coreos_site.yml
+++ b/ansible/aws_coreos_site.yml
@@ -169,6 +169,10 @@
 
     - debug: msg="cluster_elb dns {{ cluster_elb.elb.dns_name }}"
 
+    - name: Set termination protection for production clusters
+      set_fact:
+        termination_protection: "{% if env == 'p' %} 'yes' {% else %} 'no' {% endif %}"
+
     - name: Provision m3.large instances
       ec2:
         aws_access_key: "{{ aws_access_key_id }}"
@@ -198,6 +202,7 @@
           teamDL: "{{teamDL}}"
           stopSchedule: "nostop"
           coco-environment-tag: "{{environment_tag}}"
+        termination_protection: "{{ termination_protection }}"
 
     - name: Provision m3.large instances
       ec2:
@@ -228,6 +233,7 @@
           teamDL: "{{teamDL}}"
           stopSchedule: "nostop"
           coco-environment-tag: "{{environment_tag}}"
+        termination_protection: "{{ termination_protection }}"
 
     - set_fact:
         persistent_tag: 1
@@ -266,6 +272,7 @@
           teamDL: "{{teamDL}}"
           stopSchedule: "nostop"
           coco-environment-tag: "{{environment_tag}}"
+        termination_protection: "{{ termination_protection }}"
 
     - set_fact:
         persistent_tag: 2
@@ -304,6 +311,7 @@
           teamDL: "{{teamDL}}"
           stopSchedule: "nostop"
           coco-environment-tag: "{{environment_tag}}"
+        termination_protection: "{{ termination_protection }}"
 
     - set_fact:
         persistent_tag: 3
@@ -342,6 +350,7 @@
           teamDL: "{{teamDL}}"
           stopSchedule: "nostop"
           coco-environment-tag: "{{environment_tag}}"
+        termination_protection: "{{ termination_protection }}"
 
     - name: Cluster tunnel DNS address
       debug: msg="Cluster tunnel DNS address - {{ environment_tag }}-tunnel-up.ft.com"


### PR DESCRIPTION
If environment_type is production, automagically enable termination protection.  

Otherwise leave it turned off, like we currently do.