### PR TITLE
Fix DNS decomissioning

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ RUN echo "[localhost]" > ~/.ansible_hosts \
  && mkdir .venv \
  && virtualenv .venv \
  && . .venv/bin/activate \
- && pip install ansible==2.0.1.0 boto awscli
+ && pip install ansible==2.0.2.0 boto awscli
 
 ADD *.sh /
 ADD cluster-id-extractor /

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ docker run \
     -e "API_HOST=$API_HOST" \
     -e "CLUSTER_BASIC_HTTP_CREDENTIALS=$CLUSTER_BASIC_HTTP_CREDENTIALS" \
     -e "ENVIRONMENT_TYPE=$ENVIRONMENT_TYPE" \
-    coco/coco-provisioner:v1.0.11
+    coco/coco-provisioner:v1.0.12
 
 ```
 
@@ -90,7 +90,7 @@ docker run \
   -e "AWS_DEFAULT_REGION=$AWS_DEFAULT_REGION" \
   -e "AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY" \
   -e "AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID" \
-  coco/coco-provisioner:v1.0.11 /bin/bash /decom.sh
+  coco/coco-provisioner:v1.0.12 /bin/bash /decom.sh
 ```
 
 Coco Management Server

--- a/ansible/decom.yml
+++ b/ansible/decom.yml
@@ -7,14 +7,6 @@
     - keys.yaml
 
   tasks:
-    - name: Terminate instances
-      ec2:
-        aws_access_key: "{{ aws_access_key_id }}"
-        aws_secret_key: "{{ aws_secret_access_key }}"
-        region: "{{region}}"
-        state: absent
-        instance_ids: "{{instanceIds}}"
-
     - name: Delete DNS tunnel record
       uri:
         url: "https://dns-api.in.ft.com/v2/"
@@ -33,16 +25,6 @@
         body:
           zone: "ft.com"
           name: "{{environment_tag}}-up"
-        body_format: json
-
-    - name: Delete DNS ELB read record
-      uri:
-        url: "https://dns-api.in.ft.com/v2/"
-        method: DELETE
-        HEADER_x-api-key: "{{konstructor_api_key}}"
-        body:
-          zone: "ft.com"
-          name: "{{environment_tag}}-up-read"
         body_format: json
 
     - name: Wait 120s for instances to be terminated and release enis

--- a/ansible/decom.yml
+++ b/ansible/decom.yml
@@ -17,32 +17,32 @@
 
     - name: Delete DNS tunnel record
       uri:
-        url: https://dns-api.in.ft.com/v2/
+        url: "https://dns-api.in.ft.com/v2/"
         method: DELETE
-        HEADER_x-api-key: {{konstructor_api_key}}
+        HEADER_x-api-key: "{{konstructor_api_key}}"
         body:
-          zone: ft.com
-          name: {{environment_tag}}-tunnel-up
+          zone: "ft.com"
+          name: "{{environment_tag}}-tunnel-up"
         body_format: json
       
     - name: Delete DNS ELB record
       uri:
-        url: https://dns-api.in.ft.com/v2/
+        url: "https://dns-api.in.ft.com/v2/"
         method: DELETE
-        HEADER_x-api-key: {{konstructor_api_key}}
+        HEADER_x-api-key: "{{konstructor_api_key}}"
         body:
-          zone: ft.com
-          name: {{environment_tag}}-up
+          zone: "ft.com"
+          name: "{{environment_tag}}-up"
         body_format: json
 
     - name: Delete DNS ELB read record
       uri:
-        url: https://dns-api.in.ft.com/v2/
+        url: "https://dns-api.in.ft.com/v2/"
         method: DELETE
-        HEADER_x-api-key: {{konstructor_api_key}}
+        HEADER_x-api-key: "{{konstructor_api_key}}"
         body:
-          zone: ft.com
-          name: {{environment_tag}}-up-read
+          zone: "ft.com"
+          name: "{{environment_tag}}-up-read"
         body_format: json
 
     - name: Wait 120s for instances to be terminated and release enis

--- a/ansible/decom.yml
+++ b/ansible/decom.yml
@@ -16,13 +16,28 @@
         instance_ids: "{{instanceIds}}"
 
     - name: Delete DNS tunnel record
-      shell: "curl -s -L -X DELETE -H \"Content-Length: 0\" -H \"Accept: application/json\" -H \"Authorization: Basic {{konstructor_api_key}} \" \"https://konstructor.ft.com/v1/dns/delete?zone=ft.com&name={{environment_tag}}-tunnel-up\""
+      uri:
+        url: https://dns-api.in.ft.com/v2/
+        method: DELETE
+        HEADER_Content-Type: application/json
+        HEADER_x-api-key: {{konstructor_api_key}}
+        body: "{\"zone\":\"ft.com\",\"name\":\"{{environment_tag}}-tunnel-up\"}"
+      
+    - name: Delete DNS ELB record
+      uri:
+        url: https://dns-api.in.ft.com/v2/
+        method: DELETE
+        HEADER_Content-Type: application/json
+        HEADER_x-api-key: {{konstructor_api_key}}
+        body: "{\"zone\":\"ft.com\",\"name\":\"{{environment_tag}}-up\"}"
 
-    - name: Delete DNS elb record
-      shell: "curl -s -L -X DELETE -H \"Content-Length: 0\" -H \"Accept: application/json\" -H \"Authorization: Basic {{konstructor_api_key}} \" \"https://konstructor.ft.com/v1/dns/delete?zone=ft.com&name={{environment_tag}}-up\""
-
-    - name: Delete DNS elb read record
-      shell: "curl -s -L -X DELETE -H \"Content-Length: 0\" -H \"Accept: application/json\" -H \"Authorization: Basic {{konstructor_api_key}} \" \"https://konstructor.ft.com/v1/dns/delete?zone=ft.com&name={{environment_tag}}-up-read\""
+      - name: Delete DNS ELB read record
+      uri:
+        url: https://dns-api.in.ft.com/v2/
+        method: DELETE
+        HEADER_Content-Type: application/json
+        HEADER_x-api-key: {{konstructor_api_key}}
+        body: "{\"zone\":\"ft.com\",\"name\":\"{{environment_tag}}-up-read\"}"
 
     - name: Wait 120s for instances to be terminated and release enis
       shell: "sleep 120"

--- a/ansible/decom.yml
+++ b/ansible/decom.yml
@@ -7,6 +7,14 @@
     - keys.yaml
 
   tasks:
+    - name: Terminate instances
+      ec2:
+        aws_access_key: "{{ aws_access_key_id }}"
+        aws_secret_key: "{{ aws_secret_access_key }}"
+        region: "{{region}}"
+        state: absent
+        instance_ids: "{{instanceIds}}"
+
     - name: Delete DNS tunnel record
       uri:
         url: "https://dns-api.in.ft.com/v2/"
@@ -25,6 +33,16 @@
         body:
           zone: "ft.com"
           name: "{{environment_tag}}-up"
+        body_format: json
+
+    - name: Delete DNS ELB read record
+      uri:
+        url: "https://dns-api.in.ft.com/v2/"
+        method: DELETE
+        HEADER_x-api-key: "{{konstructor_api_key}}"
+        body:
+          zone: "ft.com"
+          name: "{{environment_tag}}-up-read"
         body_format: json
 
     - name: Wait 120s for instances to be terminated and release enis

--- a/ansible/decom.yml
+++ b/ansible/decom.yml
@@ -35,16 +35,6 @@
           name: "{{environment_tag}}-up"
         body_format: json
 
-    - name: Delete DNS ELB read record
-      uri:
-        url: "https://dns-api.in.ft.com/v2/"
-        method: DELETE
-        HEADER_x-api-key: "{{konstructor_api_key}}"
-        body:
-          zone: "ft.com"
-          name: "{{environment_tag}}-up-read"
-        body_format: json
-
     - name: Wait 120s for instances to be terminated and release enis
       shell: "sleep 120"
 

--- a/ansible/decom.yml
+++ b/ansible/decom.yml
@@ -19,25 +19,31 @@
       uri:
         url: https://dns-api.in.ft.com/v2/
         method: DELETE
-        HEADER_Content-Type: application/json
         HEADER_x-api-key: {{konstructor_api_key}}
-        body: "{\"zone\":\"ft.com\",\"name\":\"{{environment_tag}}-tunnel-up\"}"
+        body:
+          zone: ft.com
+          name: {{environment_tag}}-tunnel-up
+        body_format: json
       
     - name: Delete DNS ELB record
       uri:
         url: https://dns-api.in.ft.com/v2/
         method: DELETE
-        HEADER_Content-Type: application/json
         HEADER_x-api-key: {{konstructor_api_key}}
-        body: "{\"zone\":\"ft.com\",\"name\":\"{{environment_tag}}-up\"}"
+        body:
+          zone: ft.com
+          name: {{environment_tag}}-up
+        body_format: json
 
-      - name: Delete DNS ELB read record
+    - name: Delete DNS ELB read record
       uri:
         url: https://dns-api.in.ft.com/v2/
         method: DELETE
-        HEADER_Content-Type: application/json
         HEADER_x-api-key: {{konstructor_api_key}}
-        body: "{\"zone\":\"ft.com\",\"name\":\"{{environment_tag}}-up-read\"}"
+        body:
+          zone: ft.com
+          name: {{environment_tag}}-up-read
+        body_format: json
 
     - name: Wait 120s for instances to be terminated and release enis
       shell: "sleep 120"


### PR DESCRIPTION
The decomissioning playbook was still using Konstructor v1, which has been disabled, so none of our DNS records were getting removed when clusters were decomissioned.

Now updated to use Konstructor v2, and also uses Ansible's URI method instead of `curl`ing. Minor Ansible version bump to accomodate this.