### PR TITLE
Mask update engine

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ docker run \
     -e "API_HOST=$API_HOST" \
     -e "CLUSTER_BASIC_HTTP_CREDENTIALS=$CLUSTER_BASIC_HTTP_CREDENTIALS" \
     -e "ENVIRONMENT_TYPE=$ENVIRONMENT_TYPE" \
-    coco/coco-provisioner:v1.0.14
+    coco/coco-provisioner:v1.0.15
 
 ```
 
@@ -90,7 +90,7 @@ docker run \
   -e "AWS_DEFAULT_REGION=$AWS_DEFAULT_REGION" \
   -e "AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY" \
   -e "AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID" \
-  coco/coco-provisioner:v1.0.14 /bin/bash /decom.sh
+  coco/coco-provisioner:v1.0.15 /bin/bash /decom.sh
 ```
 
 Coco Management Server

--- a/ansible/userdata/default_instance_user_data.yaml
+++ b/ansible/userdata/default_instance_user_data.yaml
@@ -20,6 +20,7 @@ coreos:
   units:
     - name: update-engine.service
       command: stop
+      mask: true
     - name: locksmithd.service
       command: stop
     - name: authorized_keys.service

--- a/ansible/userdata/persistent_instance_user_data.yaml
+++ b/ansible/userdata/persistent_instance_user_data.yaml
@@ -22,6 +22,7 @@ coreos:
   units:
     - name: update-engine.service
       command: stop
+      mask: true
     - name: locksmithd.service
       command: stop
     - name: authorized_keys.service


### PR DESCRIPTION
* automating the masking of the update-engine
* part of the new coreos upgrade process, see https://github.com/Financial-Times/coreos-upgrade/pull/2
* built a cluster with this, works, I can unmask the service and start it:

```
~ $ sudo systemctl status update-engine
● update-engine.service
   Loaded: masked (/dev/null; bad)
   Active: failed (Result: exit-code) since Mon 2016-10-10 07:40:18 UTC; 3min 28s ago

~ $ sudo systemctl unmask update-engine
Removed symlink /etc/systemd/system/update-engine.service.
~ $ sudo systemctl status update-engine
● update-engine.service - Update Engine
   Loaded: loaded (/usr/lib64/systemd/system/update-engine.service; disabled; vendor preset: disabled)
   Active: failed (Result: exit-code) since Mon 2016-10-10 07:40:18 UTC; 3min 42s ago

~ $ sudo systemctl start update-engine
~ $ journalctl -fu update-engine
-- Logs begin at Mon 2016-10-10 07:39:53 UTC. --
systemd[1]: Starting Update Engine...
update_engine[1410]: [1010/075711:INFO:main.cc(155)] CoreOS Update Engine starting
systemd[1]: Started Update Engine.
update_engine[1410]: [1010/075711:INFO:update_check_scheduler.cc(82)] Next update check in 8m3s
```