### PR TITLE
Disabling journald rate limiting

### DIFF
--- a/ansible/userdata/default_instance_user_data.yaml
+++ b/ansible/userdata/default_instance_user_data.yaml
@@ -159,3 +159,5 @@ write_files:
       [Journal]
       MaxLevelConsole=crit
       Compress=false
+      RateLimitInterval=0
+      RateLimitBurst=0

--- a/ansible/userdata/persistent_instance_user_data.yaml
+++ b/ansible/userdata/persistent_instance_user_data.yaml
@@ -115,4 +115,5 @@ write_files:
       [Journal]
       MaxLevelConsole=crit
       Compress=false
-      
+      RateLimitInterval=0
+      RateLimitBurst=0


### PR DESCRIPTION
Disables journald's default rate limits for new clusters.