### PR TITLE
Feature/notifications rw add cluster id to etcd

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 private.md
 envvars.bash
 .vscode/
+/.project

--- a/DEVELOPER_README.md
+++ b/DEVELOPER_README.md
@@ -95,8 +95,7 @@ export METHODE_API=
 Run the locally created image
 -----------------------------
 
-Currently, attempting to provision a cluster in `us-east-1` with an environment type of `t` causes the security group creation to fail.
-Everything else works fine - `t` or `p` clusters in `eu-west-1`, and `p` clusters in `us-east-1`.
+You can provision `t` or `p` clusters in `eu-west-1` and `us-east-1`.
 
 ```bash
 docker run \

--- a/README.md
+++ b/README.md
@@ -29,8 +29,7 @@ See [SSH_README.md](/SSH_README.md/)
 Provision a delivery cluster
 ------------------------------
 
-Currently, attempting to provision a cluster in `us-east-1` with an environment type of `t` causes the security group creation to fail.
-Everything else works fine - `t` or `p` clusters in `eu-west-1`, and `p` clusters in `us-east-1`.
+You can provision `t` or `p` clusters in `eu-west-1` and `us-east-1`.
 
 ```bash
 ## Set all the environment variables required to provision a cluster. These variables are stored in LastPass

--- a/ansible/userdata/default_instance_user_data.yaml
+++ b/ansible/userdata/default_instance_user_data.yaml
@@ -110,6 +110,7 @@ coreos:
           ExecStart=/bin/sh -c "etcdctl mk /ft/_credentials/kafka-bridge-pub-prod/authorization_key '{{ pub_prod_credentials }}'                >/dev/null 2>&1 || true;"
           ExecStart=/bin/sh -c "etcdctl mk /ft/_credentials/upp-gateway/authorization_key '{{ upp_gateway_credentials }}'                       >/dev/null 2>&1 || true;"
           ExecStart=/bin/sh -c "etcdctl mk /ft/config/environment_tag '{{environment_tag}}'                                                     >/dev/null 2>&1 || true;"
+          ExecStart=/bin/sh -c "etcdctl mk /ft/config/cluster_id '{{clusterid}}'                                                                >/dev/null 2>&1 || true;"
           ExecStart=/bin/sh -c "etcdctl mk /ft/config/api_host '{{api_host}}'                                                                   >/dev/null 2>&1 || true;"
           ExecStart=/bin/sh -c "etcdctl mk /ft/config/aws_region '{{region}}'                                                                   >/dev/null 2>&1 || true;"
           ExecStart=/bin/sh -c "etcdctl mk /ft/config/cache-max-age 10                                                                          >/dev/null 2>&1 || true;"


### PR DESCRIPTION
Add (short) cluster id to etcd as `/ft/config/cluster_id` so that it can be injected into the notifications-rw service.
Also verified that the restriction on provisioning test clusters in us-east-1 no longer applies and updated the README files accordingly.